### PR TITLE
Enhance GraphQL API with Field Selection (info) and Data Compliance

### DIFF
--- a/schema/schema.py
+++ b/schema/schema.py
@@ -4,6 +4,7 @@ from strawberry.types import Info
 from models.model import AnnoqSampleData, PersonType, AnnoqDataType
 
 from resolvers.resolver import get_annotations, get_sample_annotations, search_by_ID
+from utils import get_selected_fields
 
 @strawberry.type
 class Query:
@@ -14,13 +15,15 @@ class Query:
     
     
     @strawberry.field
-    async def sample_annotations(self, info: Info) -> List[AnnoqSampleData]:
+    async def sample_annotations(self, info: Info) -> List[AnnoqSampleData]:     
         return await get_sample_annotations()
     
 
     @strawberry.field
-    async def annotations(self, info: Info) -> List[AnnoqDataType]:
-        return await get_annotations()
+    async def annotations(self, info: Info) -> List[AnnoqDataType]: 
+        print(info)
+        fields = get_selected_fields(info)
+        return await get_annotations(fields)
     
     @strawberry.field
     def hello(self) -> PersonType:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+import re
+from strawberry.types import Info
+
+def convert_camel_case(name):
+    pattern = re.compile(r'(?<!^)(?=[A-Z])')
+    name = pattern.sub('_', name).lower()
+    return name
+
+def get_selected_fields(info:Info):
+    selected_fields = [convert_camel_case(field.name)  for field in info.selected_fields[0].selections]
+    return selected_fields
+


### PR DESCRIPTION
### Changes

- **Selective Field Loading**: Now, our GraphQL annotations resolver dynamically fetches only the client-requested fields from Elasticsearch, reducing data transfer and processing. This solves the "AnnoqDataType.__init__() got an unexpected keyword argument 'ANNOVAR_ensembl_Closest_gene(intergenic_only)'", so if you dont select that field, it will not error out
- **GraphQL Compliance Conversion**: Implemented a conversion layer to transform Elasticsearch data into GraphQL-compliant format, addressing naming convention discrepancies. Not finished, just add more like removing (), - to _ etc