### PR TITLE
Keyword search and bug fixes

### DIFF
--- a/src/graphql/models/annotation_model.py
+++ b/src/graphql/models/annotation_model.py
@@ -23,7 +23,7 @@ class DocCount:
 
 @strawberry.input
 class Histogram:
-    interval: Optional[int] = 4893.27
+    interval: Optional[float] = 4893.27
     min: Optional[int] = 10636
     max: Optional[int] = 499963
 

--- a/src/graphql/resolvers/count_resolver.py
+++ b/src/graphql/resolvers/count_resolver.py
@@ -1,7 +1,7 @@
 from ...config.es import es
 from ...config.settings import settings
-from src.graphql.models.annotation_model import FilterArgs, PageArgs
-from .helper_resolver import IDs_query, annotation_query, chromosome_query, convert_hits, gene_query, get_aggregation_query, rsID_query, rsIDs_query
+from src.graphql.models.annotation_model import FilterArgs
+from .helper_resolver import IDs_query, annotation_query, chromosome_query, gene_query, keyword_query, rsID_query, rsIDs_query
 
 
 async def get_annotations_count():
@@ -107,3 +107,18 @@ async def count_by_gene(gene:str, filter_args=FilterArgs):
         return resp['count']
       
       return 0
+
+async def count_by_keyword(keyword: str):
+      """ 
+      Query for getting count of annotation by keyword
+
+      Params: 
+            keyword: Keyword to search
+
+      Returns: integer for count of annotations
+      """
+      resp = await es.count(
+            index = settings.ES_INDEX,
+            query = keyword_query(keyword)
+      )
+      return resp['count']

--- a/src/graphql/resolvers/helper_resolver.py
+++ b/src/graphql/resolvers/helper_resolver.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import typing
 from typing import Dict
 from src.graphql.gene_pos import get_pos_from_gene_id, map_gene, chromosomal_location_dic
 from src.graphql.models.snp_model import ScrollSnp, Snp, SnpAggs
@@ -263,7 +264,7 @@ async def get_aggregation_query(aggregation_fields: list[tuple[str, list[str]]],
 
         # Check the type of the field. If it is a string, then we have to add .keyword to the field name while querying missing and frequency
         # Using the pydantic model Snp, we can check the type of the field
-        is_text_field = inspect.get_annotations(Snp)[field] == str
+        is_text_field = typing.get_args(inspect.get_annotations(Snp)[field])[0] == str
         textual_suffix = '.keyword' if is_text_field else ''
              
         for subfield in subfields:

--- a/src/graphql/resolvers/snp_resolver.py
+++ b/src/graphql/resolvers/snp_resolver.py
@@ -2,7 +2,7 @@ from src.config.es import es
 from src.config.settings import settings
 from src.graphql.resolvers.download_resolver import download_annotations
 from src.graphql.models.annotation_model import FilterArgs, Histogram, PageArgs, QueryType
-from src.graphql.resolvers.helper_resolver import IDs_query, annotation_query, chromosome_query, convert_aggs, convert_hits, convert_scroll_hits, gene_query, get_aggregation_query, rsID_query, rsIDs_query
+from src.graphql.resolvers.helper_resolver import IDs_query, annotation_query, chromosome_query, convert_aggs, convert_hits, convert_scroll_hits, gene_query, get_aggregation_query, get_default_aggregation_fields, keyword_query, rsID_query, rsIDs_query
 
 
 async def query_return(query_type, es_fields, resp):
@@ -30,12 +30,13 @@ async def query_return(query_type, es_fields, resp):
     return results
 
 
-async def get_annotations(es_fields: list[str], query_type: str, histogram=Histogram):
+async def get_annotations(es_fields: list[str], query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, histogram=Histogram):
     """ 
     Query for getting all annotations, no filter, size 20
 
     Params: es_fields: List of fields to be returned in elasticsearch query
             query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
             histogram: Histogram object for aggregation query
 
     Returns: List of Snps
@@ -44,7 +45,7 @@ async def get_annotations(es_fields: list[str], query_type: str, histogram=Histo
           index = settings.ES_INDEX,
           source = es_fields,
           query = annotation_query(),
-          aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
           size = 20,
           scroll = '2m' if query_type == QueryType.DOWNLOAD else None
     )
@@ -68,7 +69,7 @@ async def scroll_annotations_(scroll_id: str):
     return results
 
 
-async def search_by_chromosome(es_fields: list[str], chr: str, start: int, end: int, query_type: str, page_args=PageArgs, filter_args=FilterArgs,
+async def search_by_chromosome(es_fields: list[str], chr: str, start: int, end: int, query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, filter_args=FilterArgs,
                                histogram=Histogram):
     """ 
     Query for getting annotation by chromosome with start and end range of pos
@@ -78,6 +79,7 @@ async def search_by_chromosome(es_fields: list[str], chr: str, start: int, end: 
             start: Start position
             end: End position
             query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
             page_args: PageArgs object for pagination
             filter_args: FilterArgs object for field exists filter
             histogram: Histogram object for aggregation query
@@ -96,20 +98,21 @@ async def search_by_chromosome(es_fields: list[str], chr: str, start: int, end: 
           from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
           size = page_args.size,
           query = chromosome_query(chr, start, end, filter_args),
-          aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
           scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
     )
 
     return await query_return(query_type, es_fields, resp)
 
 
-async def search_by_rsID(es_fields: list[str], rsID:str, query_type: str, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
+async def search_by_rsID(es_fields: list[str], rsID:str, query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
     """ 
     Query for getting annotation by rsID
 
     Params: es_fields: List of fields to be returned in elasticsearch query
             rsID: rsID of snp
             query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
             page_args: PageArgs object for pagination
             filter_args: FilterArgs object for field exists filter
             histogram: Histogram object for aggregation query
@@ -128,20 +131,21 @@ async def search_by_rsID(es_fields: list[str], rsID:str, query_type: str, page_a
           from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
           size = page_args.size,
           query = rsID_query(rsID, filter_args),
-          aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
           scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
     )
 
     return await query_return(query_type, es_fields, resp)
     
 
-async def search_by_rsIDs(es_fields: list[str], rsIDs: list[str], query_type: str, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
+async def search_by_rsIDs(es_fields: list[str], rsIDs: list[str], query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
     """ 
     Query for getting annotation by list of rsIDs
 
     Params: es_fields: List of fields to be returned in elasticsearch query
             rsIDs: List of rsIDs of snps
             query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
             page_args: PageArgs object for pagination
             filter_args: FilterArgs object for field exists filter
             histogram: Histogram object for aggregation query
@@ -160,7 +164,7 @@ async def search_by_rsIDs(es_fields: list[str], rsIDs: list[str], query_type: st
           from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
           size = page_args.size,
           query = rsIDs_query(rsIDs, filter_args),
-          aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
           scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
     )
     
@@ -168,13 +172,14 @@ async def search_by_rsIDs(es_fields: list[str], rsIDs: list[str], query_type: st
 
 
 # query for VCF file
-async def search_by_IDs(es_fields: list[str], ids: list[str], query_type: str, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
+async def search_by_IDs(es_fields: list[str], ids: list[str], query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
     """ 
     Query for getting annotation by IDs
 
     Params: es_fields: List of fields to be returned in elasticsearch query
             ids: List of IDs of snps
             query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
             page_args: PageArgs object for pagination
             filter_args: FilterArgs object for field exists filter
             histogram: Histogram object for aggregation query
@@ -193,14 +198,14 @@ async def search_by_IDs(es_fields: list[str], ids: list[str], query_type: str, p
           from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
           size = page_args.size,
           query = IDs_query(ids, filter_args),
-          aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
           scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
     )
     
     return await query_return(query_type, es_fields, resp)
 
 
-async def search_by_gene(es_fields: list[str], gene:str, query_type: str, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
+async def search_by_gene(es_fields: list[str], gene:str, query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, filter_args=FilterArgs, histogram=Histogram):
     """ 
     Query for getting annotation by gene product
 
@@ -208,6 +213,7 @@ async def search_by_gene(es_fields: list[str], gene:str, query_type: str, page_a
             gene: Gene product
             query_type: Type of query to be executed
             page_args: PageArgs object for pagination
+            aggregation_fields: List of fields for aggregation, along with their subfields
             filter_args: FilterArgs object for field exists filter
             histogram: Histogram object for aggregation query
 
@@ -228,8 +234,39 @@ async def search_by_gene(es_fields: list[str], gene:str, query_type: str, page_a
               from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
               size = page_args.size,
               query = query,
-              aggs = await get_aggregation_query(es_fields, histogram) if query_type == QueryType.AGGS else None,
+              aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
               scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
       )
       
       return await query_return(query_type, es_fields, resp)
+
+async def search_by_keyword(es_fields: list[str], keyword: str, query_type: str, aggregation_fields: list[tuple[str, list[str]]]=None, page_args=PageArgs, histogram=Histogram):
+    """ 
+    Query for getting annotation by keyword
+
+    Params: es_fields: List of fields to be returned in elasticsearch query
+            keyword: Keyword to be searched
+            query_type: Type of query to be executed
+            aggregation_fields: List of fields for aggregation, along with their subfields
+            page_args: PageArgs object for pagination
+            histogram: Histogram object for aggregation query
+
+    Returns: List of Snps
+    """
+    if page_args is None:
+      page_args = PageArgs
+
+    if histogram is None:
+      histogram = Histogram
+
+    resp = await es.search(
+          index = settings.ES_INDEX,
+          source = es_fields,
+          from_= page_args.from_ if (query_type != QueryType.DOWNLOAD and query_type != QueryType.SCROLL) else None,
+          size = page_args.size,
+          query = keyword_query(keyword),
+          aggs = await get_aggregation_query(aggregation_fields or get_default_aggregation_fields(es_fields), histogram) if query_type == QueryType.AGGS else None,
+          scroll = '2m' if (query_type == QueryType.DOWNLOAD or query_type == QueryType.SCROLL) else None
+    )
+    
+    return await query_return(query_type, es_fields, resp)

--- a/src/graphql/schema.py
+++ b/src/graphql/schema.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 import strawberry
 from strawberry.types import Info
-from src.graphql.models.snp_model import ScrollSnp, Snp, SnpAggs
+from src.graphql.models.snp_model import ScrollSnp, SnpAggs
 from src.graphql.models.annotation_model import FilterArgs, Histogram, PageArgs, QueryType, QueryTypeOption
 
-from src.graphql.resolvers.snp_resolver import get_annotations, scroll_annotations_, search_by_chromosome, search_by_gene, search_by_rsID, search_by_rsIDs, search_by_IDs
-from src.graphql.resolvers.count_resolver import count_by_IDs, count_by_chromosome, count_by_gene, count_by_rsID, count_by_rsIDs, get_annotations_count
-from src.utils import get_selected_fields, get_sub_selected_fields
+from src.graphql.resolvers.snp_resolver import get_annotations, scroll_annotations_, search_by_chromosome, search_by_gene, search_by_keyword, search_by_rsID, search_by_rsIDs, search_by_IDs
+from src.graphql.resolvers.count_resolver import count_by_IDs, count_by_chromosome, count_by_gene, count_by_keyword, count_by_rsID, count_by_rsIDs, get_annotations_count
+from src.utils import get_selected_fields, get_sub_selected_fields, get_aggregation_fields
 
 class CustomError(Exception):
     def __init__(self, message: str):
@@ -45,15 +45,16 @@ class Query:
             query_type = QueryType.SNPS
         else:
             query_type = QueryType.SCROLL
-        return await search_by_chromosome(fields, chr, start, end, query_type, page_args, filter_args)
+        return await search_by_chromosome(fields, chr, start, end, query_type, None, page_args, filter_args)
     
     @strawberry.field
     async def get_aggs_by_chromosome(self, info: Info, chr: str, start: int, end: int,
-                                  page_args: Optional[PageArgs] = None, histogram: Optional[Histogram] = None) -> SnpAggs:
+                                  page_args: Optional[PageArgs] = None, histogram: Optional[Histogram] = None, filter_args: Optional[FilterArgs] = None) -> SnpAggs:
         fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
         if page_args is not None:
             page_args.size = 0
-        return await search_by_chromosome(fields, chr, start, end, QueryType.AGGS, page_args, None, histogram)
+        return await search_by_chromosome(fields, chr, start, end, QueryType.AGGS, aggregation_fields, page_args, filter_args, histogram)
     
     @strawberry.field
     async def count_SNPs_by_chromosome(self, chr: str, start: int, end: int, filter_args: Optional[FilterArgs] = None) -> int:
@@ -61,8 +62,8 @@ class Query:
     
     @strawberry.field
     async def download_SNPs_by_chromosome(self, chr: str, start: int, end: int, fields: list[str],
-                                  page_args: Optional[PageArgs] = None) -> str:
-        return await search_by_chromosome(fields, chr, start, end, QueryType.DOWNLOAD, page_args) 
+                                  page_args: Optional[PageArgs] = None, filter_args: Optional[FilterArgs] = None) -> str:
+        return await search_by_chromosome(fields, chr, start, end, QueryType.DOWNLOAD, None, page_args, filter_args) 
     
 
     @strawberry.field
@@ -74,16 +75,17 @@ class Query:
             query_type = QueryType.SNPS
         else:
             query_type = QueryType.SCROLL
-        return await search_by_rsID(fields, rsID, query_type, page_args, filter_args)
+        return await search_by_rsID(fields, rsID, query_type, None, page_args, filter_args)
     
     @strawberry.field
     async def get_aggs_by_RsID(self, info: Info, rsID: str,
                                   page_args: Optional[PageArgs] = None,
-                                  histogram: Optional[Histogram] = None) -> SnpAggs:
+                                  histogram: Optional[Histogram] = None, filter_args: Optional[FilterArgs] = None) -> SnpAggs:
         fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
         if page_args is not None:
             page_args.size = 0
-        return await search_by_rsID(fields, rsID, QueryType.AGGS, page_args, None, histogram)
+        return await search_by_rsID(fields, rsID, QueryType.AGGS, aggregation_fields, page_args, filter_args, histogram)
     
     @strawberry.field
     async def count_SNPs_by_RsID(self, rsID: str, filter_args: Optional[FilterArgs] = None) -> int:
@@ -91,8 +93,8 @@ class Query:
     
     @strawberry.field
     async def download_SNPs_by_RsID(self, rsID: str, fields: list[str],
-                            page_args: Optional[PageArgs] = None) -> str:
-        return await search_by_rsID(fields, rsID, QueryType.DOWNLOAD, page_args)
+                            page_args: Optional[PageArgs] = None, filter_args: Optional[FilterArgs] = None) -> str:
+        return await search_by_rsID(fields, rsID, QueryType.DOWNLOAD, None, page_args, filter_args)
     
 
     @strawberry.field
@@ -104,16 +106,17 @@ class Query:
             query_type = QueryType.SNPS
         else:
             query_type = QueryType.SCROLL
-        return await search_by_rsIDs(fields, rsIDs, query_type, page_args, filter_args)
+        return await search_by_rsIDs(fields, rsIDs, query_type, None, page_args, filter_args)
     
     @strawberry.field
     async def get_aggs_by_RsIDs(self, info: Info, rsIDs: list[str],
                                   page_args: Optional[PageArgs] = None,
-                                  histogram: Optional[Histogram] = None) -> SnpAggs:
+                                  histogram: Optional[Histogram] = None, filter_args: Optional[FilterArgs] = None) -> SnpAggs:
         fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
         if page_args is not None:
             page_args.size = 0
-        return await search_by_rsIDs(fields, rsIDs, QueryType.AGGS, page_args, None, histogram)
+        return await search_by_rsIDs(fields, rsIDs, QueryType.AGGS, aggregation_fields, page_args, filter_args, histogram)
     
     @strawberry.field
     async def count_SNPs_by_RsIDs(self, rsIDs: list[str], filter_args: Optional[FilterArgs] = None) -> int:
@@ -121,8 +124,8 @@ class Query:
     
     @strawberry.field
     async def download_SNPs_by_RsIDs(self, rsIDs: list[str], fields: list[str],
-                             page_args: Optional[PageArgs] = None) -> str:
-        return await search_by_rsIDs(fields, rsIDs, QueryType.DOWNLOAD, page_args)
+                             page_args: Optional[PageArgs] = None, filter_args: Optional[FilterArgs] = None) -> str:
+        return await search_by_rsIDs(fields, rsIDs, QueryType.DOWNLOAD, None, page_args, filter_args)
     
      
     @strawberry.field
@@ -134,16 +137,17 @@ class Query:
             query_type = QueryType.SNPS
         else:
             query_type = QueryType.SCROLL
-        return await search_by_IDs(fields, ids, query_type, page_args, filter_args)
+        return await search_by_IDs(fields, ids, query_type, None, page_args, filter_args)
     
     @strawberry.field
     async def get_aggs_by_IDs(self, info: Info, ids: list[str],
                                   page_args: Optional[PageArgs] = None,
-                                  histogram: Optional[Histogram] = None) -> SnpAggs:
+                                  histogram: Optional[Histogram] = None, filter_args: Optional[FilterArgs] = None) -> SnpAggs:
         fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
         if page_args is not None:
             page_args.size = 0
-        return await search_by_IDs(fields, ids, QueryType.AGGS, page_args, None, histogram)
+        return await search_by_IDs(fields, ids, QueryType.AGGS, aggregation_fields, page_args, filter_args, histogram)
     
     @strawberry.field
     async def count_SNPs_by_IDs(self, ids: list[str], filter_args: Optional[FilterArgs] = None) -> int:
@@ -151,8 +155,8 @@ class Query:
     
     @strawberry.field
     async def download_SNPs_by_IDs(self, ids: list[str], fields: list[str],
-                          page_args: Optional[PageArgs] = None) -> str:
-        return await search_by_IDs(fields, ids, QueryType.DOWNLOAD, page_args)
+                          page_args: Optional[PageArgs] = None, filter_args: Optional[FilterArgs] = None) -> str:
+        return await search_by_IDs(fields, ids, QueryType.DOWNLOAD, None, page_args, filter_args)
     
     
     @strawberry.field
@@ -164,16 +168,17 @@ class Query:
             query_type = QueryType.SNPS
         else:
             query_type = QueryType.SCROLL
-        return await search_by_gene(fields, gene, query_type, page_args, filter_args)
+        return await search_by_gene(fields, gene, query_type, None, page_args, filter_args)
     
     @strawberry.field
     async def get_aggs_by_gene_product(self, info: Info, gene: str, 
                                   page_args: Optional[PageArgs] = None,
-                                  histogram: Optional[Histogram] = None) -> SnpAggs:
+                                  histogram: Optional[Histogram] = None, filter_args: Optional[FilterArgs] = None) -> SnpAggs:
         fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
         if page_args is not None:
             page_args.size = 0
-        return await search_by_gene(fields, gene, QueryType.AGGS, page_args, None, histogram)
+        return await search_by_gene(fields, gene, QueryType.AGGS, aggregation_fields, page_args, filter_args, histogram)
     
     @strawberry.field
     async def count_SNPs_by_gene_product(self, gene: str, filter_args: Optional[FilterArgs] = None) -> int:
@@ -181,5 +186,34 @@ class Query:
     
     @strawberry.field
     async def download_SNPs_by_gene_product(self, gene: str, fields: list[str],
-                                   page_args: Optional[PageArgs] = None) -> str:
-        return await search_by_gene(fields, gene, QueryType.DOWNLOAD, page_args)
+                                   page_args: Optional[PageArgs] = None, filter_args: Optional[FilterArgs] = None) -> str:
+        return await search_by_gene(fields, gene, QueryType.DOWNLOAD, None, page_args, filter_args)
+    
+    @strawberry.field
+    async def get_SNPs_by_keyword(self, info: Info, keyword: str, query_type_option: QueryTypeOption,
+                            page_args: Optional[PageArgs] = None) -> ScrollSnp:
+        fields = get_sub_selected_fields(info)
+        if query_type_option == QueryTypeOption.SNPS:
+            query_type = QueryType.SNPS
+        else:
+            query_type = QueryType.SCROLL
+        return await search_by_keyword(fields, keyword, query_type, None, page_args)
+    
+    @strawberry.field
+    async def get_aggs_by_keyword(self, info: Info, keyword: str,
+                                  page_args: Optional[PageArgs] = None,
+                                  histogram: Optional[Histogram] = None) -> SnpAggs:
+        fields = get_selected_fields(info)
+        aggregation_fields = get_aggregation_fields(info)
+        if page_args is not None:
+            page_args.size = 0
+        return await search_by_keyword(fields, keyword, QueryType.AGGS, aggregation_fields, page_args, histogram)
+    
+    @strawberry.field
+    async def count_SNPs_by_keyword(self, keyword: str) -> int:
+        return await count_by_keyword(keyword)
+    
+    @strawberry.field
+    async def download_SNPs_by_keyword(self, keyword: str, fields: list[str],
+                            page_args: Optional[PageArgs] = None) -> str:
+        return await search_by_keyword(fields, keyword, QueryType.DOWNLOAD, None, page_args)

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,3 +25,13 @@ def clean_field_name(name):
     
     return name
 
+
+def get_aggregation_fields(info: Info) -> list[tuple[str, list[str]]]:
+    '''
+    Get aggregation fields from the query, along with the subfields
+    '''
+
+    aggregation_fields = []
+    for field in info.selected_fields[0].selections:
+        aggregation_fields.append((field.name, [subfield.name for subfield in field.selections]))
+    return aggregation_fields


### PR DESCRIPTION
# Overview

This PR is used to fix API issues wherein the data being returned by this API is not consistent with the data requested.
It also implements the keyword search functionality for querying annotations.

# Issues Targeted
Fixes #43
Fixes #42 
Fixes #41 

# Changes 

- Added filters to the get aggregations and download SNPs functions. Used the same logic that was already present in the get_SNPs functions.
- Added keyword search functionality. For this, copied the same functional structure from the other querying methods (get by chromosome, rsID, etc.). 
- Fixed the issue wherein we always requested for the aggregations of the pos field instead of the field actually requested. For this, created a helper function that parses the graphql query to figure out the aggregations requested by the user for each field. Used this information to query the aggregations.
- Added special handling for fields of string type. Added the ".keyword" suffix to the end of the names of the fields that are of string type. This is done in accordance with the querying method used in the current API-V1 (that's being currently used in the annoq site.)